### PR TITLE
AGFS/LGFS Defendant Details pages

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -84,15 +84,7 @@ $(document).ready(function() {
   });
 
 
-  $('.fx-duplicate').on('click', '.button', function(e){
-    var selector = $(e.delegateTarget).data('selector');
 
-    $($(selector).not(':visible')[0]).removeClass('hidden');
-
-    if(!($(selector).not(':visible')[0])){
-      $('.fx-duplicate').remove()
-    }
-  });
 
 
   moj.init();

--- a/app/assets/javascripts/modules/moj.Modules.Defendants.js
+++ b/app/assets/javascripts/modules/moj.Modules.Defendants.js
@@ -2,6 +2,8 @@ moj.Modules.Defendants = {
   el: '.fx-defendant',
   init: function() {
     this.setInitState();
+
+
   },
   // View state logic used when page is loaded.
   setInitState: function() {
@@ -10,7 +12,7 @@ moj.Modules.Defendants = {
     // apply the current display states based on the
     // firstname in this case.
     $(this.el).is(function(idx, el) {
-      if($(this).find('.fx-defendant-hook').val()){
+      if ($(this).find('.fx-defendant-hook').val()) {
         $(el).removeClass('hidden');
       }
     });

--- a/app/assets/javascripts/modules/moj.Modules.RemoveLinks.js
+++ b/app/assets/javascripts/modules/moj.Modules.RemoveLinks.js
@@ -2,5 +2,15 @@ moj.Modules.RemoveLinks = {
   el: '.fx-remove-link',
   init: function() {
 
+    $('.fx-duplicate').on('click', '.button', function(e) {
+      var selector = $(e.delegateTarget).data('selector');
+
+      $($(selector).not(':visible')[0]).removeClass('hidden');
+
+      if (!($(selector).not(':visible')[0])) {
+        $('.fx-duplicate').remove()
+      }
+
+    });
   }
 }

--- a/app/views/macros/elements.html
+++ b/app/views/macros/elements.html
@@ -434,19 +434,28 @@ value="{{item.text}}">
   <div class="form-section">
     {{FORM.input(data[0], formcache, seedNum)}}
     {{FORM.input(data[1], formcache, seedNum)}}
-  </div>
-
-  <div class="form-section">
     {{FORM.date(data[2], formcache, seedNum)}}
     {{FORM.checkboxlist(data[3], formcache, seedNum)}}
-  </div>
 
-  <h3 class="heading-medium">
-    Representation order details
-  </h3>
-  <div class="form-section">
+    <details role="group">
+      <summary role="button" aria-controls="details-content-0" aria-expanded="false">
+        <span class="summary">Help with judicial apportionment</span>
+      </summary>
+      <div class="panel panel-border-narrow" id="details-content-0" aria-hidden="true">
+        <p>
+          Judicial apportionment is when the defendant has applied for and received an order confirming they are not required to pay the full amount of their defence costs. If applicable, please ensure you upload a copy of the order to your claim.
+        </p>
+      </div>
+    </details>
+
+    <h3 class="heading-medium">
+      Representation order details
+    </h3>
+
     {{FORM.date(data[4], formcache, seedNum)}}
     {{FORM.input(data[5], formcache, seedNum)}}
+
+    <a href="#noop">Add another representation order</a>
   </div>
   <hr />
 </div>
@@ -461,19 +470,28 @@ value="{{item.text}}">
   <div class="form-section">
     {{FORM.input(data[0], formcache, seedNum)}}
     {{FORM.input(data[1], formcache, seedNum)}}
-  </div>
-
-  <div class="form-section">
     {{FORM.date(data[2], formcache, seedNum)}}
     {{FORM.checkboxlist(data[3], formcache, seedNum)}}
-  </div>
 
-  <h3 class="heading-medium">
-    Representation order details
-  </h3>
-  <div class="form-section">
+    <details role="group">
+      <summary role="button" aria-controls="details-content-0" aria-expanded="false">
+        <span class="summary">Help with judicial apportionment</span>
+      </summary>
+      <div class="panel panel-border-narrow" id="details-content-0" aria-hidden="true">
+        <p>
+          Judicial apportionment is when the defendant has applied for and received an order confirming they are not required to pay the full amount of their defence costs. If applicable, please ensure you upload a copy of the order to your claim.
+        </p>
+      </div>
+    </details>
+
+    <h3 class="heading-medium">
+      Representation order details
+    </h3>
+
     {{FORM.date(data[4], formcache, seedNum)}}
     {{FORM.input(data[5], formcache, seedNum)}}
+
+    <a href="#noop">Add another representation order</a>
   </div>
   <hr />
 </div>


### PR DESCRIPTION
There are three pages here:

AGFS Multi page
LGFS Lookup page
LGFS Single page

All three update:
- added help link/text for judicial apportionment
- semantic changes to form sections
- added “Add another representation order” link